### PR TITLE
fix: find <link> tags

### DIFF
--- a/src/routes/api/links/+server.ts
+++ b/src/routes/api/links/+server.ts
@@ -49,7 +49,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
     const html = parse(text);
     const links = html
-      .querySelectorAll(`a[href='${linkBack}']`)
+      .querySelectorAll(`a[href='${linkBack}'],link[href='${linkBack}']`)
       .map(({ attributes }) => ({ href: attributes.href, rel: attributes.rel.split(' ') }));
 
     const bodySize = text.length;


### PR DESCRIPTION
This PR changes the link-finding code to also look for `<link>` tags in addition to `<a>` links. Mastodon also looks for these when verifying a profile.